### PR TITLE
dependent destroy

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,7 +1,7 @@
 class Book < ActiveRecord::Base
   include GoodReadsFetcher
 
-  has_one :read
+  has_one :read, dependent: :destroy
   validates_uniqueness_of :title, scope: :author
   validates_presence_of :title, :author
 


### PR DESCRIPTION
When GoodReads makes a subtle change to the title of a book it will create a second copy of the book in the database. Temp fix right now is to connect to the database and delete the FIRST copy of the book in the database. 

Perm fix is to store ISBN and check by ISBN. 
